### PR TITLE
Docs: Update out-of-date examples & typography values

### DIFF
--- a/packages/backpack-tokens/docs/.vuepress/config.js
+++ b/packages/backpack-tokens/docs/.vuepress/config.js
@@ -4,7 +4,7 @@ module.exports = {
     nav: [
       { text: 'Colour', link: '/colour/showbie/' },
       { text: 'Type', link: '/type/showbie/' },
-      { text: 'GitHub', link: 'https://github.com/showbie/backpack-tokens' },
+      { text: 'GitHub', link: 'https://github.com/showbie/backpack' },
     ],
 
     sidebar: {

--- a/packages/backpack-tokens/docs/colour/showbie/README.md
+++ b/packages/backpack-tokens/docs/colour/showbie/README.md
@@ -62,6 +62,10 @@ two approaches.
 
 <ColorSwatch hue="grey" scale="200" />
 
+### Grey 400
+
+<ColorSwatch hue="grey" scale="400" />
+
 ### Grey 500
 
 <ColorSwatch hue="grey" scale="500" />

--- a/packages/backpack-tokens/docs/type/socrative/README.md
+++ b/packages/backpack-tokens/docs/type/socrative/README.md
@@ -9,9 +9,9 @@ Socrative uses two different fonts throughout the app: most text is set in [Inte
 Font sizes within the app are confined to a fairly narrow range.
 
 <figure class="mh0 mv5">
-  <SizeSwatch name="xs" value="1rem" family="Inter" />
-  <SizeSwatch name="sm" value="1.083334rem" family="Inter" />
-  <SizeSwatch name="base" value="1.25rem" family="Inter" />
+  <SizeSwatch name="xs" value="1.08334rem" family="Inter" />
+  <SizeSwatch name="sm" value="1.25rem" family="Inter" />
+  <SizeSwatch name="base" value="1.33334rem" family="Inter" />
 </figure>
 
 These three smaller sizes should only be used with Inter. Montserrat does not render well this small.
@@ -29,10 +29,13 @@ Larger font sizes should be used for Montserrat, rarely for Inter.
 
 <figure class="mh0 mv5">
   <WeightSwatch weight="400" name="regular" family="Inter" />
+  <WeightSwatch weight="500" name="medium" family="Inter" />
   <WeightSwatch weight="600" name="semibold" family="Inter" />
+  <WeightSwatch weight="700" name="bold" family="Inter" />
 </figure>
 
-Inter is available in these two weights. Italics may be available in the future.
+Inter is available in these four weights. Italics are available at each of these
+weights as well.
 
 <figure class="mh0 mv5">
   <WeightSwatch weight="500" name="medium" family="Montserrat" />


### PR DESCRIPTION
Adds missing swatch for Showbie Grey-400.
Updates Socrative typography docs around usage of Inter.