### PR TITLE
New: Add new colour shades to Socrative palette

### DIFF
--- a/.changeset/witty-carrots-push.md
+++ b/.changeset/witty-carrots-push.md
@@ -1,0 +1,5 @@
+---
+'@showbie/backpack-tokens': minor
+---
+
+Add new colours to Socrative palette

--- a/.changeset/witty-carrots-push.md
+++ b/.changeset/witty-carrots-push.md
@@ -2,4 +2,7 @@
 '@showbie/backpack-tokens': minor
 ---
 
-Add new colours to Socrative palette
+Add new colours to Socrative palette  
+Adds `300` and `900`-level shades of red, `800`-level orange, and
+`700`, `800`, and `900`-level shades of green. This also decouples
+the red values from the Showbie palette, making it standalone.

--- a/packages/backpack-tokens/docs/colour/socrative/README.md
+++ b/packages/backpack-tokens/docs/colour/socrative/README.md
@@ -60,8 +60,9 @@
 ## Red
 
 ::: tip NOTE
-These colours are mapped to the same reds as the
-[Showbie palette](../showbie/#red) — updating there will update these as well.
+These colours were initially based on the reds from the 
+[Showbie palette](../showbie/#red). The hue has been decoupled from that palette
+in order to include new shades.
 :::
 
 ### Red 50
@@ -75,6 +76,10 @@ These colours are mapped to the same reds as the
 ### Red 200
 
 <ColorSwatch theme="socrative" hue="red" scale="200" />
+
+### Red 300
+
+<ColorSwatch theme="socrative" hue="red" scale="300" />
 
 ### Red 500
 
@@ -91,6 +96,11 @@ These colours are mapped to the same reds as the
 ### Red 800
 
 <ColorSwatch theme="socrative" hue="red" scale="800" />
+
+### Red 900
+
+<ColorSwatch theme="socrative" hue="red" scale="900" />
+
 
 ## Orange
 
@@ -113,6 +123,10 @@ These colours are mapped to the same reds as the
 ### Orange 700
 
 <ColorSwatch theme="socrative" hue="orange" scale="700" />
+
+### Orange 800
+
+<ColorSwatch theme="socrative" hue="orange" scale="800" />
 
 ## Amber
 
@@ -161,6 +175,18 @@ These colours are mapped to the same reds as the
 ### Green 600
 
 <ColorSwatch theme="socrative" hue="green" scale="600" />
+
+### Green 700
+
+<ColorSwatch theme="socrative" hue="green" scale="700" />
+
+### Green 800
+
+<ColorSwatch theme="socrative" hue="green" scale="800" />
+
+### Green 900
+
+<ColorSwatch theme="socrative" hue="green" scale="900" />
 
 ## Cyan
 

--- a/packages/backpack-tokens/src/backpack-socrative.ts
+++ b/packages/backpack-tokens/src/backpack-socrative.ts
@@ -1,5 +1,3 @@
-import { colors as SHOWBIE } from './backpack-showbie';
-
 export const colors = {
   grey: {
     50: '#f5f7f8',
@@ -14,7 +12,18 @@ export const colors = {
     900: '',
   },
 
-  red: SHOWBIE.red,
+  red: {
+    50: '#ffeeee',
+    100: '#fce5e5',
+    200: '#f9cccc',
+    300: '#f5b2b2',
+    400: '',
+    500: '#f07f7f',
+    600: '#eb5f5f',
+    700: '#e13c3c',
+    800: '#e10000',
+    900: '#4d2828',
+  },
 
   orange: {
     50: '#ffece6',
@@ -25,7 +34,7 @@ export const colors = {
     500: '',
     600: '#ff753f',
     700: '#ed580f',
-    800: '',
+    800: '#d14600',
     900: '',
   },
 
@@ -50,9 +59,9 @@ export const colors = {
     400: '',
     500: '#5dbe6e',
     600: '#49af5b',
-    700: '',
-    800: '',
-    900: '',
+    700: '#2d953f',
+    800: '#008a19',
+    900: '#284d2f',
   },
 
   cyan: {

--- a/packages/backpack-tokens/yarn.lock
+++ b/packages/backpack-tokens/yarn.lock
@@ -882,10 +882,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.1.tgz#238eb34a66431b71d2aaddeaa7db166f25971a0d"
   integrity sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA==
 
-"@types/node@13.7.4":
-  version "13.7.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
-  integrity sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==
+"@types/node@13.7.7":
+  version "13.7.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
+  integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -2170,10 +2170,10 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name-list@5.3.x:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/color-name-list/-/color-name-list-5.3.0.tgz#320ea7eb44ffd72af005d9ca2a622ee44a86fb70"
-  integrity sha512-b2bi03LqOM9IdcGFwOYseCiffMvX92Ophpu0dMCd5hSzUUTwHzc/N2EwW8OZ/rLDNj3vMw84uQyjiBGcnYER0w==
+color-name-list@5.30.x:
+  version "5.30.0"
+  resolved "https://registry.yarnpkg.com/color-name-list/-/color-name-list-5.30.0.tgz#f7d5ef8187251a623ba537ffe9156b4ec72a4852"
+  integrity sha512-JmlMljFTfO+JQQ0s11x/6C0d4VkQhx6MM7wKpSb2lKsr5c1RfHymuFXM+Rps9EBCXB4CDtH3oQ98ondERHyOjA==
 
 color-name@1.1.3:
   version "1.1.3"
@@ -7524,10 +7524,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -8045,7 +8045,7 @@ websocket-driver@>=0.5.1:
     safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
-websocket-extensions@0.1.4, websocket-extensions@>=0.1.1:
+websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==


### PR DESCRIPTION
Adds `300` and `900`-level shades of red, `800`-level orange, and
`700`, `800`, and `900`-level shades of green. This also decouples
the red values from the Showbie palette, making it standalone.