### PR TITLE
New: Allow subdirs in icon source directory

### DIFF
--- a/.changeset/mighty-onions-brake.md
+++ b/.changeset/mighty-onions-brake.md
@@ -1,0 +1,9 @@
+---
+'stickerbomb': minor
+---
+
+Allow subdirs in icon source directory
+
+Components are now generated into the same directory structure as
+the original source SVGs. An export index will be added for each
+sub-directory (in the case of React components).

--- a/packages/stickerbomb/src/sortFilePaths.ts
+++ b/packages/stickerbomb/src/sortFilePaths.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+
+import globby from 'globby';
+
+import { IconSets } from './types';
+
+export async function sortFilePaths(iconsDir: string): Promise<IconSets> {
+  let svgFilePaths = await globby(iconsDir, {
+    absolute: true,
+  });
+  let rootPath = path.parse(path.parse(iconsDir).dir).dir;
+  let iconSets = svgFilePaths.reduce((acc, cur) => {
+    let pathParts = cur.split(path.sep);
+    let subpath = path.join(
+      ...pathParts.slice(pathParts.indexOf(rootPath) + 1, pathParts.length - 1)
+    );
+
+    if (!acc[subpath]) {
+      acc = { ...acc, [subpath]: [] };
+    }
+
+    acc[subpath].push(cur);
+
+    return acc;
+  }, {} as IconSets);
+
+  return iconSets;
+}

--- a/packages/stickerbomb/src/types.ts
+++ b/packages/stickerbomb/src/types.ts
@@ -1,1 +1,2 @@
 export type FormatOption = 'react' | 'ember';
+export type IconSets = Record<string, string[]>;


### PR DESCRIPTION
Stickerbomb will now generate components into the same directory
structure as the original source SVGs. An export index will be added
for each sub-directory (in the case of React components).
